### PR TITLE
Remove warnings and bump CUDA version for PyTorch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ termcolor==1.1.0
 thinc==8.0.8
 threadpoolctl==2.1.0
 tokenizers==0.10.2
-torch==1.8.1
+torch==1.8.1+cu111
 tqdm==4.60.0
 transformers==4.6.0
 typer==0.3.2
@@ -86,3 +86,5 @@ wcwidth==0.2.5
 Werkzeug==2.0.1
 wrapt==1.12.1
 zipp==3.4.1
+
+--find-links https://download.pytorch.org/whl/torch_stable.html

--- a/transferability_script.py
+++ b/transferability_script.py
@@ -1,5 +1,12 @@
 import argparse
 import warnings
+import os
+from transformers.utils import logging
+
+warnings.filterwarnings("ignore")
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+logging.set_verbosity_error()
+
 from nlp.transferability.bert_transferability import evaluate_bert
 from nlp.transferability.lstm_transferability import evaluate_LSTM
 from nlp.transferability.fasttext_transferability import evaluate_fasttext


### PR DESCRIPTION
Remove warnings from the HuggingFace library and bump the CUDA version used to build PyTorch to 11 to work with the Ampere GPUs